### PR TITLE
fix(ast): remove reference side effect in debugDumpTree

### DIFF
--- a/src/compiler/ast.ts
+++ b/src/compiler/ast.ts
@@ -98,7 +98,7 @@ export class CallTreeNode extends BaseTreeNode {
   }
 
   getChildren(): BaseTreeNode[] {
-    const childList: BaseTreeNode[] = this.argList;
+    const childList: BaseTreeNode[] = [...this.argList];
     if (this.styling) childList.push(this.styling);
     return childList;
   }
@@ -134,7 +134,7 @@ export class AssignmentTreeNode extends BaseTreeNode {
   }
 
   getChildren(): BaseTreeNode[] {
-    const childList: BaseTreeNode[] = this.lhs;
+    const childList: BaseTreeNode[] = [...this.lhs];
     if (this.rhs) childList.push(this.rhs);
     return childList;
   }

--- a/tests/unit/compiler/ast.test.ts
+++ b/tests/unit/compiler/ast.test.ts
@@ -1,0 +1,30 @@
+import { describe, test, expect } from "vitest";
+import {
+  RecipeTreeNode as Recipe,
+  CallTreeNode as Call,
+  AssignmentTreeNode as Assignment,
+  AliasTreeNode as Alias,
+  LocalVarTreeNode as LocalVariable,
+  QualifiedVarTreeNode as QualifiedVariable,
+  StyleTreeNode as Style,
+  NamedStyleTreeNode as NamedStyle,
+  NamespaceTreeNode as Namespace,
+} from "src/compiler/ast";
+
+describe("debugDumpTree consistency", () => {
+  test("dumping nodes with children has no side effects", () => {
+    const callNode = new Call("f", []);
+    const assignmentNode = new Assignment([new LocalVariable("x")], callNode);
+    const aliasNode = new Alias(
+      new LocalVariable("y"),
+      new QualifiedVariable(["x"]),
+    );
+    const namedStyleNode = new NamedStyle("s", new Style(new Map()));
+    const namespaceNode = new Namespace("n", [assignmentNode, aliasNode]);
+    const recipeNode = new Recipe([namespaceNode, namedStyleNode]);
+
+    const firstDump = recipeNode.debugDumpTree();
+    const secondDump = recipeNode.debugDumpTree();
+    expect(firstDump).toEqual(secondDump);
+  });
+});


### PR DESCRIPTION
fix a bug in the AST debugDumpTree that kept appending to the initial list because it was assigned a reference and not value